### PR TITLE
Replace usage of FabricLoaderImpl in LoadingScreenManager

### DIFF
--- a/src/main/java/com/ishland/earlyloadingscreen/LoadingScreenManager.java
+++ b/src/main/java/com/ishland/earlyloadingscreen/LoadingScreenManager.java
@@ -10,8 +10,6 @@ import com.ishland.earlyloadingscreen.render.GLText;
 import com.ishland.earlyloadingscreen.render.Simple2DDraw;
 import com.ishland.earlyloadingscreen.util.WindowCreationUtil;
 import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.impl.FabricLoaderImpl;
-import net.fabricmc.loader.impl.util.Arguments;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.Callbacks;
@@ -211,12 +209,18 @@ public class LoadingScreenManager {
         GLFW.glfwWindowHint(GLFW.GLFW_OPENGL_FORWARD_COMPAT, 1);
         int configuredWidth = 854;
         int configuredHeight = 480;
-        try {
-            final Arguments arguments = FabricLoaderImpl.INSTANCE.getGameProvider().getArguments();
-            configuredWidth = Integer.parseInt(arguments.getOrDefault("width", "854"));
-            configuredHeight = Integer.parseInt(arguments.getOrDefault("height", "480"));
-        } catch (Throwable t) {
-            LOGGER.error("Failed to load window configuration", t);
+        final String[] args = FabricLoader.getInstance().getLaunchArguments(true);
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if (i + 1 < args.length && arg.startsWith("--")) {
+                arg = arg.substring(2).toLowerCase(Locale.ROOT);
+                if (arg.equals("width")) {
+                    configuredWidth = Integer.parseInt(args[i + 1]);
+                }
+                if (arg.equals("height")) {
+                    configuredHeight = Integer.parseInt(args[i + 1]);
+                }
+            }
         }
         String minecraftVersion = "Unknown";
         try {


### PR DESCRIPTION
This PR replaces the usage of `FabricLoaderImpl` in `LoadingScreenManager` by using the public-facing `FabricLoader#getLaunchArguments` method instead of `FabricLoaderImpl.getGameProvider#getArguments`.

This allows getting the window width / height on Quilt, which does not implement `FabricLoaderImpl`.

(feel free to change the target branch if you'd like to merge it into the 1.20.4 version first; it *should* be version-independent)